### PR TITLE
Update repo URL

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ VCS_REF=$(git rev-parse --short HEAD)
 
 # Fetch the latest Kali debootstrap script from git
 curl "http://git.kali.org/gitweb/?p=packages/debootstrap.git;a=blob_plain;f=scripts/kali;h=50d7ef5b4e9e905cc6da8655416cdf3ef559911e;hb=refs/heads/kali/master" > kali-debootstrap &&\
-sudo debootstrap kali-rolling ./kali-root http://repo.kali.org/kali ./kali-debootstrap &&\
+sudo debootstrap kali-rolling ./kali-root https://http.kali.org/kali ./kali-debootstrap &&\
 sudo tar -C kali-root -c . | sudo docker import - kalilinux/kali-linux-docker &&\
 sudo rm -rf ./kali-root &&\
 TAG=$(sudo docker run -t -i kalilinux/kali-linux-docker awk '{print $NF}' /etc/debian_version | sed 's/\r$//' ) &&\


### PR DESCRIPTION
Script breaks with old repo URL since it changed. Now it works.

Fixes #18 